### PR TITLE
Fix for Android build issues

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -181,6 +181,7 @@ android {
 }
 
 dependencies {
+    implementation 'com.google.firebase:firebase-messaging:17.3.0'
     implementation fileTree(dir: "libs", include: ["*.jar"])
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -40,7 +40,7 @@
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
 
-      <receiver android:enabled="true" android:exported="false" android:name="com.pushio.manager.PushIOUriReceiver" tools:node="replace">
+      <receiver android:enabled="true" android:exported="false" android:name="com.pushio.manager.PushIOUriReceiver">
           <intent-filter>
               <action android:name="android.intent.action.VIEW" />
               <category android:name="android.intent.category.DEFAULT" />
@@ -48,7 +48,7 @@
           </intent-filter>
       </receiver>
       <activity android:name="com.pushio.manager.iam.ui.PushIOMessageViewActivity" android:permission="${applicationId}.permission.SHOW_IAM" android:theme="@android:style/Theme.Translucent.NoTitleBar">
-          <intent-filter tools:ignore="AppLinkUrlError">
+          <intent-filter>
           <action android:name="android.intent.action.VIEW" />
               <category android:name="android.intent.category.BROWSABLE" />
               <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
- Added the firebase-messaging dependency, and,
- Removed the `tools` attribute in the manifest.

The [plugin documentation](https://github.com/oracle/pushiomanager-react-native) is updated with the above changes.

Before you build again, please remove the plugin and add it again.

`yarn remove react-native-pushiomanager`
`yarn add https://github.com/oracle/pushiomanager-react-native.git`